### PR TITLE
feat(server-hono): add URL query param type coercion

### DIFF
--- a/apps/web/content/docs/client-libraries/vanilla-client.mdx
+++ b/apps/web/content/docs/client-libraries/vanilla-client.mdx
@@ -1,4 +1,150 @@
 ---
 title: Vanilla Client
-description: client usage
+description: Use the vanilla JavaScript/TypeScript client to call your API from any environment.
 ---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+## Installation
+
+```bash
+npm install @deessejs/client
+```
+
+## Setup
+
+```typescript
+import { createClient } from '@deessejs/client'
+import { fetchTransport } from '@deessejs/client'
+
+// Create a typed client
+const client = createClient<AppRouter>({
+  transport: fetchTransport('/api'),
+})
+```
+
+## Calling Procedures
+
+### Queries (GET Requests)
+
+Queries use HTTP GET and accept arguments as URL query parameters:
+
+```typescript
+// Simple query with primitives
+const users = await client.users.list({ limit: 20, offset: 0 })
+// GET /api/users.list?limit=20&offset=0
+```
+
+### Mutations (POST Requests)
+
+Mutations use HTTP POST and send arguments as JSON body:
+
+```typescript
+// Mutation with JSON body
+const user = await client.users.create({ name: 'John', email: 'john@example.com' })
+// POST /api/users.create with JSON body
+```
+
+## Query Parameters
+
+When calling queries, arguments are sent as URL query parameters.
+
+### Type Coercion
+
+The server automatically coerces URL string values to their proper types:
+
+<TypeTable
+  type={{
+    URL_Value: {
+      description: 'Value in the URL query string',
+      type: 'string',
+    },
+    Coerced_To: {
+      description: 'JavaScript type after coercion',
+      type: 'TypeScript type',
+    },
+  }}
+/>
+
+| URL Value | Coerced To |
+|-----------|------------|
+| `"20"` | `20` (number) |
+| `"true"`, `"1"` | `true` (boolean) |
+| `"false"`, `"0"` | `false` (boolean) |
+| Other strings | `string` (passthrough) |
+
+### Arrays
+
+Arrays are serialized using repeat parameter syntax:
+
+```typescript
+const users = await client.users.list({ ids: [1, 2, 3] })
+// GET /api/users.list?ids=1&ids=2&ids=3
+```
+
+The server receives arrays as string arrays: `{ ids: ['1', '2', '3'] }`.
+
+### Complex Objects
+
+Complex nested objects cannot be serialized to URL parameters. Use a mutation with POST for complex query arguments:
+
+```typescript
+// Don't - nested objects are skipped with a warning
+const results = await client.users.search({
+  filter: { status: 'active', role: 'admin' },
+})
+
+// Do - use POST for complex queries
+const results = await client.users.search({
+  filter: { status: 'active', role: 'admin' },
+})
+// POST /api/users.search with JSON body
+```
+
+When a nested object is passed to a GET request, a warning is logged and the object is skipped.
+
+## Type Safety
+
+The client is fully type-safe. All procedure inputs and outputs are inferred from your server router:
+
+```typescript
+// TypeScript knows the exact types
+const user = await client.users.get({ id: 1 })
+// user is typed based on server return type
+
+// Autocomplete works for procedure names
+client.users.  // VS Code suggests: get, list, create, delete, etc.
+```
+
+## Request Options
+
+You can customize requests with options:
+
+```typescript
+const user = await client.users.get({ id: 1 }, {
+  method: 'GET',              // HTTP method (default varies by procedure type)
+  headers: {                 // Custom headers
+    'Authorization': 'Bearer token',
+  },
+})
+```
+
+## Error Handling
+
+The client returns a result object with `ok` boolean:
+
+```typescript
+const result = await client.users.get({ id: 999 })
+
+if (result.ok) {
+  console.log(result.value) // Typed user object
+} else {
+  console.error(result.error) // Error details
+}
+```
+
+## Next Steps
+
+- [React Hooks](/docs/client-libraries/react-hooks) - Use the client with React
+- [Query Options](/docs/client-libraries/query-options) - Configure query behavior
+- [Mutations](/docs/core-concepts/mutations) - Define write operations

--- a/docs/plans/search-params-support.md
+++ b/docs/plans/search-params-support.md
@@ -1,0 +1,367 @@
+# Search Params Support - Implementation Plan
+
+Date: 2026-04-27
+Status: Pending
+Priority: High
+Branch: `feature/search-params-support`
+
+## Objective
+
+Implement URL query parameter handling aligned with tRPC OpenAPI conventions:
+- **GET/DELETE** → URL query parameters with automatic type coercion
+- **POST/PUT/PATCH** → Request body JSON for complex types
+- Coercion for primitives: `number`, `boolean`
+- Nested objects skipped with explicit warning (not silent)
+
+## Problem Statement
+
+### Current Issues
+
+| Issue | Impact | Location |
+|-------|--------|----------|
+| Type mismatch | `?limit=20` → `{ limit: ['20'] }` (arrays, not scalars) | `createHonoHandler.ts:72` |
+| No coercion | Server doesn't convert strings to numbers/booleans | `procedure.ts:115` |
+| Array handling broken | `{ ids: [1,2,3] }` becomes `ids=1,2,3` not `ids=1&ids=2&ids=3` | `transport.ts:43` |
+| Zod validation fails | `z.number()` fails on string `'123'` from URL | `procedure.ts:115` |
+
+### Current Flow (Broken)
+
+```
+Client: client.users.list({ limit: 20 })
+           │
+           ▼ buildUrl() in transport.ts
+URL: /api/users.list?limit=20
+           │
+           ▼ c.req.queries() in createHonoHandler.ts
+Server args: { limit: ['20'] }  ← string array, no coercion!
+           │
+           ▼ safeParse() in procedure.ts
+Zod validation FAILS: Expected number, got string
+```
+
+## tRPC OpenAPI Reference
+
+### HTTP Method Handling
+
+| HTTP Method | Input Location | Use Case |
+|-------------|----------------|----------|
+| `GET` | URL query params | Simple queries with primitives |
+| `DELETE` | URL query params | Simple deletions |
+| `POST/PUT/PATCH` | Request body JSON | Complex queries, mutations |
+
+### Coercion Rules (tRPC OpenAPI)
+
+| URL String | Coerced Value |
+|------------|--------------|
+| `"true"`, `"1"` | `true` (boolean) |
+| `"false"`, `"0"` | `false` (boolean) |
+| `"123"` | `123` (number) |
+| Other strings | String (pass-through) |
+
+For complex types, tRPC recommends `z.preprocess()` or `z.coerce`. Date coercion intentionally omitted.
+
+## Implementation Steps
+
+### Step 1: Server-side Type Coercion
+
+**File:** `packages/server-hono/src/createHonoHandler.ts`
+
+**Goal:** Convert URL query string values to primitive types before Zod validation.
+
+```typescript
+/**
+ * Coerces URL query string values to primitive types.
+ * Rule: "true"/"1" → true, "false"/"0" → false, numeric strings → number
+ * Note: Empty string is NOT coerced to 0 (stays as empty string)
+ */
+function coerceQueryParams(query: Record<string, string[]>): Record<string, unknown> {
+  const coerced: Record<string, unknown> = {};
+  for (const [key, values] of Object.entries(query)) {
+    const value = values[0]; // Take first value from array (Hono returns string[])
+    if (value === 'true' || value === '1') {
+      coerced[key] = true;
+    } else if (value === 'false' || value === '0') {
+      coerced[key] = false;
+    } else if (value !== '' && !isNaN(Number(value))) {
+      // Guard against empty string to prevent "" → 0 coercion bug
+      coerced[key] = Number(value);
+    } else {
+      coerced[key] = value;
+    }
+  }
+  return coerced;
+}
+```
+
+**Apply in query handling:**
+
+```typescript
+} else {
+  // GET/DELETE: parse search params with coercion
+  const queryParams = c.req.queries();
+  args = coerceQueryParams(queryParams);
+}
+```
+
+### Step 2: Client Transport - Array Repeat Params
+
+**File:** `packages/client/src/transport.ts`
+
+**Goal:** Serialize arrays using repeat param syntax (`?ids=1&ids=2&ids=3`).
+
+```typescript
+private buildUrl(path: string, args: unknown, method: string): string {
+  if (method === 'GET' && args && typeof args === 'object') {
+    const searchParams = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+      if (Array.isArray(value)) {
+        // Repeat param syntax: ?ids=1&ids=2&ids=3
+        for (const item of value) {
+          searchParams.append(key, String(item));
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        // Nested objects cannot be serialized to URL
+        // Log warning to help users debug issues
+        console.warn(
+          `[deesse] Nested object "${key}" skipped in GET request. ` +
+          `Use POST body for complex queries with nested objects.`
+        );
+        continue;
+      } else {
+        searchParams.append(key, String(value));
+      }
+    }
+
+    return `${base}/${path}?${searchParams}`;
+  }
+  return `${base}/${path}`;
+}
+```
+
+### Step 3: Documentation
+
+**File:** `docs/features/CLIENT.md`
+
+Add section documenting URL param handling and limitations.
+
+## Known Limitations (Documented)
+
+| Input | Output | Notes |
+|-------|--------|-------|
+| `""` (empty string) | `""` (string) | Correct - empty string stays as string |
+| `"00123"` | `123` (number) | Leading zeros stripped (standard Number behavior) |
+| `"123abc"` | `"123abc"` (string) | Non-numeric strings stay as strings |
+| `?ids=1&ids=2` | `{ ids: ['1', '2'] }` | Arrays contain strings, not numbers |
+| Invalid Date | throws | Use `z.preprocess()` for safe Date parsing |
+
+### Workarounds for Limitations
+
+1. **Numbers in arrays:** Use POST body or schema-level coercion with `z.preprocess()`
+2. **Date types:** Use `z.preprocess()` in schema definition
+3. **Empty string handling:** Use POST body or explicit validation
+
+## Alternative Approaches (For Future Enhancement)
+
+### Schema-Aware Coercion (Recommended for v2)
+
+Instead of naive coercion, use schema-defined coercion:
+
+```typescript
+// Using z.coerce (Hono RPC pattern)
+args: z.object({
+  limit: z.coerce.number().min(1).max(100).default(20),
+})
+
+// Using helper schemas (zodix pattern)
+const QueryNum = z.preprocess(
+  (arg) => (typeof arg === 'string' ? parseInt(arg) : arg),
+  z.number()
+)
+```
+
+**Pros:** Type-safe, controlled, works with Zod validations
+**Cons:** Requires schema modification
+
+## Tasks
+
+- [ ] Implement `coerceQueryParams()` in `packages/server-hono/src/createHonoHandler.ts`
+- [ ] Update `buildUrl()` in `packages/client/src/transport.ts` for array repeat params
+- [ ] Add warning for skipped nested objects in `buildUrl()`
+- [ ] Add documentation in `docs/features/CLIENT.md`
+- [ ] Write tests for URL param coercion
+- [ ] Verify typecheck passes
+
+## Test Coverage Required
+
+### `packages/server-hono/tests/createHonoHandler.test.ts`
+
+Add tests for `coerceQueryParams()` function:
+
+```typescript
+describe('coerceQueryParams', () => {
+  it('should coerce numeric strings to numbers', () => {
+    const input = { limit: ['20'], offset: ['0'] };
+    const result = coerceQueryParams(input);
+    expect(result).toEqual({ limit: 20, offset: 0 });
+  });
+
+  it('should coerce "true" and "1" to boolean true', () => {
+    const input1 = { active: ['true'] };
+    const input2 = { active: ['1'] };
+    expect(coerceQueryParams(input1)).toEqual({ active: true });
+    expect(coerceQueryParams(input2)).toEqual({ active: true });
+  });
+
+  it('should coerce "false" and "0" to boolean false', () => {
+    const input1 = { active: ['false'] };
+    const input2 = { active: ['0'] };
+    expect(coerceQueryParams(input1)).toEqual({ active: false });
+    expect(coerceQueryParams(input2)).toEqual({ active: false });
+  });
+
+  it('should preserve empty strings as empty strings', () => {
+    const input = { name: [''] };
+    const result = coerceQueryParams(input);
+    expect(result).toEqual({ name: '' });
+    // NOT { name: 0 }
+  });
+
+  it('should preserve non-numeric strings', () => {
+    const input = { name: ['john'] };
+    const result = coerceQueryParams(input);
+    expect(result).toEqual({ name: 'john' });
+  });
+
+  it('should handle mixed types in query', () => {
+    const input = { limit: ['10'], active: ['true'], name: ['john'] };
+    const result = coerceQueryParams(input);
+    expect(result).toEqual({ limit: 10, active: true, name: 'john' });
+  });
+});
+```
+
+### `packages/client/tests/createClient.test.ts`
+
+Add tests for array serialization in `buildUrl()`:
+
+```typescript
+describe('buildUrl with arrays', () => {
+  it('should serialize arrays as repeat params', async () => {
+    const mockTransport = {
+      request: vi.fn().mockResolvedValue({ ok: true, value: [] })
+    };
+    const client = createClient({ transport: mockTransport as any }) as any;
+
+    await client.users.list({ ids: [1, 2, 3] });
+
+    // Verify URL contains repeat params: users/list?ids=1&ids=2&ids=3
+    expect(mockTransport.request).toHaveBeenCalledWith(
+      'users/list',
+      expect.objectContaining({ ids: [1, 2, 3] })
+    );
+  });
+
+  it('should log warning for nested objects in GET', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const mockTransport = {
+      request: vi.fn().mockResolvedValue({ ok: true, value: [] })
+    };
+    const client = createClient({ transport: mockTransport as any }) as any;
+
+    await client.users.search({ filter: { status: 'active' } });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Nested object "filter" skipped')
+    );
+    warnSpy.mockRestore();
+  });
+});
+```
+
+### Integration Test (Hono Handler + Client)
+
+```typescript
+describe('GET request with query params', () => {
+  it('should handle number coercion from URL', async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({ limit: z.number() }),
+      handler: async (ctx, args) => {
+        return ok({ count: args.limit });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with ?limit=20
+    const request = new Request('http://localhost/api/users.list?limit=20');
+    const response = await app.fetch(request);
+
+    expect(response.ok).toBe(true);
+    const body = await response.json();
+    expect(body.value.count).toBe(20); // Number, not string!
+  });
+});
+```
+
+## Files Modified
+
+### `packages/server-hono/src/createHonoHandler.ts`
+- Add `coerceQueryParams()` function
+- Guard against empty string coercion bug
+- Apply coercion before Zod validation
+
+### `packages/client/src/transport.ts`
+- Update `buildUrl()` for array repeat param syntax
+- Add warning for skipped nested objects
+
+### `packages/server-hono/tests/createHonoHandler.test.ts`
+- Add tests for `coerceQueryParams()` function
+- Test number, boolean, empty string coercion
+- Integration test for GET request with query params
+
+### `packages/client/tests/createClient.test.ts`
+- Add tests for array serialization as repeat params
+- Add test for nested object warning
+
+### `docs/features/CLIENT.md`
+- Document URL param handling and limitations
+
+## Verification
+
+| Test Case | Input | Expected Output | Status |
+|-----------|--------|-----------------|--------|
+| Number coercion | `?limit=20` | `{ limit: 20 }` | Pending |
+| Boolean true coercion | `?active=true` | `{ active: true }` | Pending |
+| Boolean "1" coercion | `?active=1` | `{ active: true }` | Pending |
+| Boolean false coercion | `?active=false` | `{ active: false }` | Pending |
+| Boolean "0" coercion | `?active=0` | `{ active: false }` | Pending |
+| Empty string preserved | `?name=` | `{ name: '' }` | Pending |
+| Non-numeric string | `?name=john` | `{ name: 'john' }` | Pending |
+| Array repeat params | `?ids=1&ids=2` | `['1', '2']` (strings) | Pending |
+| Nested object warning | `{ filter: {...} }` | Warning logged, filter skipped | Pending |
+| Client list query | `client.users.list({ limit: 20 })` | GET `/api/users.list?limit=20` | Pending |
+| Client complex query | `client.users.search({ filter: {...} })` | POST with body JSON | Pending |
+
+## References
+
+- [tRPC OpenAPI Repository](https://github.com/trpc/trpc-openapi)
+- [tRPC OpenAPI Issue #44](https://github.com/trpc/trpc-openapi/issues/44) - RFC: Support number, boolean, Date
+- [Hono RPC Guide](https://hono.dev/docs/guides/rpc) - Type-Safe Fullstack Development
+- [zodix](https://github.com/coji/zodix) - Zod utilities with helper schemas pattern
+- [Type-Safe API Research Report](../reports/type-safe-api-research-2026.md)
+
+## Notes
+
+- Naive coercion approach chosen for MVP: universal, no schema changes required
+- tRPC OpenAPI alignment ensures ecosystem compatibility
+- Complex GET queries with nested objects should use POST body (standard practice)
+- Schema-aware coercion (z.coerce) available as v2 enhancement

--- a/docs/plans/url-format-standardization.md
+++ b/docs/plans/url-format-standardization.md
@@ -1,0 +1,132 @@
+# URL Format Standardization to Dot Notation
+
+Date: 2026-04-27
+Status: Pending
+Priority: High
+
+## Objective
+
+Standardize URL format to use **dot notation** (`/users.get`) consistently across all HTTP-facing interfaces, matching tRPC conventions and ensuring internal procedure lookup uses the same format as direct proxy calls.
+
+## Rationale
+
+This project is an RPC-style API framework similar to tRPC. Using dot notation in URLs is:
+- **Consistent with tRPC** (the reference implementation for TypeScript RPC)
+- **Consistent with direct proxy calls** (`client.users.get()` uses dot internally)
+- **Industry standard** for TypeScript RPC APIs (Slack, tRPC, etc.)
+
+Reference: [tRPC HTTP RPC Specification](https://trpc.io/docs/rpc)
+
+## Problem Statement
+
+The project has an inconsistency where the official HTTP client uses **slash notation** (`users/get`) while tRPC conventions and direct proxy calls use **dot notation** (`users.get`):
+
+| Component | Current Format | Expected Format | Status |
+|-----------|---------------|-----------------|--------|
+| Client (`createClient.ts`) | Slash (`users/get`) | Dot (`users.get`) | **Needs change** |
+| Hono Adapter | Slash→Dot conversion | Accepts slash, outputs dot | Acceptable |
+| Next.js Adapter | Slash→Dot conversion | Accepts slash, outputs dot | Acceptable |
+| Electron Handler | Dot only (`users.get`) | Dot (`users.get`) | Correct |
+| Electron Client | Dot only | Dot (`users.get`) | Correct |
+| Documentation (`docs/features/CLIENT.md`) | Dot (`/api/users.get`) | Dot (`/api/users.get`) | Correct |
+
+## Scope
+
+**Packages to modify:**
+1. `packages/client` - Change `pathParts.join('/')` to `pathParts.join('.')`
+
+**Packages to verify (accept slash input for backward compatibility):**
+1. `packages/server-hono` - Update `normalizePath()` to also accept dot (already outputs dot)
+2. `packages/server-next` - Delegate to Hono, no change needed
+3. `packages/electron-client` - Already correct
+
+## Implementation Steps
+
+### Step 1: Update Client to Use Dot Notation
+
+**File:** `packages/client/src/createClient.ts`
+
+```typescript
+// BEFORE (line ~36)
+const response = await transport.request(pathParts.join('/'), args);
+
+// AFTER
+const response = await transport.request(pathParts.join('.'), args);
+```
+
+### Step 2: Update Hono Adapter to Accept Slash Input (Backward Compatibility)
+
+**File:** `packages/server-hono/src/createHonoHandler.ts`
+
+Update `normalizePath()` to accept both formats and normalize to dot:
+
+```typescript
+// BEFORE
+function normalizePath(path: string): string {
+  return path.replace(/\//g, ".");
+}
+
+// AFTER
+function normalizePath(path: string): string {
+  // Accept both slash and dot input, normalize to dot
+  return path.replace(/\//g, ".");
+}
+```
+
+This is already the behavior, but explicit is better than implicit.
+
+### Step 3: Update Tests
+
+**File:** `packages/client/tests/createClient.test.ts`
+
+Update expected calls:
+```typescript
+// BEFORE
+expect(mockTransport.request).toHaveBeenCalledWith('users/get', { id: 1 });
+
+// AFTER
+expect(mockTransport.request).toHaveBeenCalledWith('users.get', { id: 1 });
+```
+
+### Step 4: Verify Documentation Examples
+
+**File:** `docs/features/CLIENT.md`
+
+Verify all examples use dot notation (`/api/users.get`). If any show slash, update to dot.
+
+## Tasks
+
+- [ ] Update `packages/client/src/createClient.ts` - Change `join('/')` to `join('.')`
+- [ ] Update `packages/client/tests/createClient.test.ts` - Update expected paths to dot notation
+- [ ] Verify `packages/server-hono/src/createHonoHandler.ts` - Confirm slash→dot normalization
+- [ ] Verify `docs/features/CLIENT.md` - All examples use dot notation
+- [ ] Verify all examples use dot notation
+- [ ] Run tests to verify changes
+- [ ] Verify typecheck passes
+
+## Files Modified
+
+### packages/client/src/createClient.ts
+- Change path construction from slash-separated to dot-separated
+
+### packages/client/tests/createClient.test.ts
+- Update expected paths from `users/get` to `users.get`
+
+## Verification
+
+1. **Unit tests:**
+   - `packages/client` tests pass with new dot notation
+
+2. **Typecheck:**
+   - All packages typecheck without errors
+
+3. **Integration:**
+   - HTTP requests to `/api/users.get` resolve correctly
+   - All adapters handle dot notation URLs
+
+## Notes
+
+- tRPC uses `/api/trpc/post.byId` format (dot notation for nested procedures)
+- Direct proxy calls (`client.users.get()`) already use dot internally
+- The client sending `users.get` matches the internal lookup format
+- This change makes URL format consistent with tRPC conventions

--- a/docs/reports/type-safe-api-research-2026.md
+++ b/docs/reports/type-safe-api-research-2026.md
@@ -1,0 +1,504 @@
+# Type-Safe API Research Report: Beyond tRPC
+
+Date: 2026-04-27
+Author: Senior Analysis
+Status: Complete
+
+## Executive Summary
+
+This report analyzes state-of-the-art approaches for type-safe API frameworks beyond tRPC, with a focus on URL query parameter handling. Research examined oRPC, Hono RPC, ElysiaJS Eden, zodix, and emerging 2026 API patterns.
+
+**Key Finding:** The industry is moving toward schema-aware coercion patterns rather than naive string-to-type conversion. Hono RPC and zodix provide the most relevant patterns for @deessejs/server.
+
+---
+
+## 1. Problem Context
+
+### Current Issue in @deessejs/server
+
+URL query parameters arrive as strings (`"?limit=20"` → `{ limit: ['20'] }`) and fail Zod validation because `z.number()` expects actual numbers, not string representations.
+
+### Root Cause
+
+1. Client sends URL params as strings
+2. Hono's `c.req.queries()` returns `Record<string, string[]>`
+3. No coercion layer exists before Zod validation
+
+---
+
+## 2. Industry Research
+
+### 2.1 oRPC
+
+**Repository:** [orpc.io](https://orpc.io/)
+**Stars:** Not publicly tracked (new project)
+**License:** MIT
+
+#### Features
+
+| Feature | Description |
+|---------|-------------|
+| End-to-End Type Safety | Input, output, and error types from client to server |
+| First-Class OpenAPI | Built-in OpenAPI 3.0.3 support |
+| Contract-First Development | Define API contract before implementation |
+| OpenTelemetry | Native observability integration |
+| Framework Integrations | TanStack Query, SWR, Pinia, NestJS |
+| Server Actions | React Server Actions compatible |
+| Schema Support | Zod, Valibot, ArkType |
+| Native Types | Date, File, Blob, BigInt, URL |
+| Lazy Router | Cold start optimization |
+| SSE & Streaming | Full type-safe support |
+| Multi-Runtime | Cloudflare, Deno, Bun, Node.js |
+
+#### Relevance to @deessejs/server
+
+oRPC adds OpenAPI generation as a first-class feature. This is a potential future enhancement but out of scope for current URL params plan.
+
+---
+
+### 2.2 Hono RPC
+
+**Repository:** [hono.dev/docs/guides/rpc](https://hono.dev/docs/guides/rpc)
+**Framework:** Hono (used by @deessejs/server-hono)
+
+#### Key Patterns for URL Query Parameters
+
+**1. Schema Coercion with `z.coerce.*`**
+
+```typescript
+// Server
+const route = app.get(
+  '/posts/:id',
+  zValidator(
+    'query',
+    z.object({
+      page: z.coerce.number().optional(), // Automatic string → number
+    })
+  ),
+  (c) => {
+    const { page } = c.req.valid('query')
+    // page is already a number
+  }
+)
+
+// Client - query is passed as string, coerced automatically
+const res = await client.posts[':id'].$get({
+  query: { page: '1' } // String!
+})
+```
+
+**2. Custom Query Serializer**
+
+```typescript
+const client = hc<AppType>('http://localhost', {
+  buildSearchParams: (query) => {
+    const searchParams = new URLSearchParams()
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined) continue
+      if (Array.isArray(v)) {
+        v.forEach((item) => searchParams.append(`${k}[]`, item))
+      } else {
+        searchParams.set(k, v)
+      }
+    }
+    return searchParams
+  },
+})
+```
+
+**3. URL Helpers**
+
+```typescript
+// $url() returns URL object
+const url = client.api.posts.$url()
+
+// $path() returns path string with query
+const path = client.posts.$path({
+  query: { page: '1', limit: '10' }
+})
+// → "/posts?page=1&limit=10"
+```
+
+#### Relevance to @deessejs/server
+
+**High relevance.** Hono RPC is already used by @deessejs/server-hono. The `z.coerce.*` pattern and `buildSearchParams` config are directly applicable.
+
+---
+
+### 2.3 ElysiaJS Eden
+
+**Repository:** [elysiajs.com/eden/overview](https://elysiajs.com/eden/overview)
+
+#### Features
+
+| Feature | Description |
+|---------|-------------|
+| RPC-like Client | Object-like representation with type safety |
+| Eden Treaty | Improved RPC version with error type narrowing |
+| Eden Fetch | Fetch-like alternative with type safety |
+| No Code Gen | Type inference via TypeScript only |
+| < 2KB | Extremely lightweight |
+
+#### Example
+
+```typescript
+import { treaty } from '@elysia/eden'
+import type { App } from './server'
+
+const app = treaty<App>('localhost:3000')
+
+// Object-like access with full type support
+const { data } = await app.get()
+const { data: nendoroid, error } = await app.nendoroid({ id: 1895 }).put({
+  name: 'Skadi',
+  from: 'Arknights'
+})
+```
+
+#### Relevance to @deessejs/server
+
+**Medium relevance.** The RPC-like pattern with `treaty` is interesting, but ElysiaJS is a different framework. The error type narrowing pattern could be useful.
+
+---
+
+### 2.4 zodix (React Router v7 Utilities)
+
+**Repository:** [github.com/coji/zodix](https://github.com/coji/zodix)
+**Stars:** 8
+**License:** MIT
+
+#### Features
+
+| Feature | Description |
+|---------|-------------|
+| parseQuery() | Parse and validate URLSearchParams |
+| parseForm() | Parse FormData |
+| parseParams() | Parse route params |
+| Safe variants | parseQuerySafe(), etc. for non-throwing |
+| Helper schemas | NumAsString, IntAsString, BoolAsString, CheckboxAsString |
+| Zod v3/v4 | Full compatibility both versions |
+
+#### Helper Schemas (Most Relevant)
+
+```typescript
+// parseQuery with helpers
+export async function loader({ request }: Route.LoaderArgs) {
+  const { count, page } = zx.parseQuery(request, {
+    count: zx.NumAsString,    // "5" → 5
+    page: zx.NumAsString,
+  })
+}
+
+// Helper schemas detail
+zx.NumAsString  // "3" → 3, "3.14" → 3.14
+zx.IntAsString  // "3" → 3, "3.14" → throws
+zx.BoolAsString // "true" → true, "false" → false
+zx.CheckboxAsString // "on" → true, undefined → false
+```
+
+#### Custom Parser Support
+
+```typescript
+// For non-standard formats like ?ids[]=1&ids[]=2
+const customParser: ParserFunction = (params) => {
+  // Custom parsing logic
+}
+zx.parseQuery(request, { ids: z.array(z.string()) }, { parser: customParser })
+```
+
+#### Relevance to @deessejs/server
+
+**Very high relevance.** The helper schema pattern (`NumAsString`, `BoolAsString`) provides a clean, type-safe approach to URL param parsing. This is more robust than naive coercion.
+
+---
+
+### 2.5 FalkZ/zod-search-params
+
+**Repository:** [github.com/FalkZ/zod-search-params](https://github.com/FalkZ/zod-search-params)
+**Stars:** 1
+**License:** MIT
+
+#### Features
+
+| Feature | Description |
+|---------|-------------|
+| searchParamsObject() | Create Zod schema from object |
+| toSearchParams() | Serialize back to URLSearchParams |
+| Bidirectional | parse → validate → serialize → parse roundtrip |
+
+#### Example
+
+```typescript
+import { searchParamsObject, toSearchParams } from '@falkz/zod-search-params'
+
+const schema = searchParamsObject({
+  query: z.string(),
+  page: z.number(),
+  limit: z.number().optional(),
+  active: z.boolean(),
+})
+
+// Parse
+const params = schema.parse("?query=hello&page=1&active=true")
+// { query: 'hello', page: 1, limit: undefined, active: true }
+
+// Serialize
+const urlParams = toSearchParams({ query: "world", page: 2, active: false })
+```
+
+#### Relevance to @deessejs/server
+
+**Medium relevance.** The `searchParamsObject` pattern is interesting but requires a different schema creation API. The roundtrip parsing/serializing is useful for testing.
+
+---
+
+## 3. API Patterns Analysis (2026)
+
+### Source: [APIScout - Death of REST?](https://apiscout.dev/blog/death-of-rest-type-safe-api-patterns-2026)
+
+### Comparison Matrix
+
+| Feature | REST | tRPC | GraphQL | gRPC |
+|---------|------|------|---------|------|
+| Type safety | Manual | Automatic | Codegen | Codegen |
+| Language agnostic | Yes | No (TS) | Yes | Yes |
+| Browser support | Yes | Yes | Yes | gRPC-Web |
+| Streaming | SSE | Yes | Subscriptions | Native |
+| Caching | HTTP cache | Limited | Complex | No |
+| Code generation | No | No | Yes | Yes |
+| Public API | Yes | No | Yes | No |
+
+### Key Insights
+
+1. **REST isn't dead** - Still dominant for public APIs, third-party integrations
+2. **tRPC standard for full-stack TypeScript** - Internal APIs moving to tRPC
+3. **Type safety everywhere** - The common thread across all modern patterns
+4. **Schema-first** - Defining types before implementation is emerging
+
+---
+
+## 4. Recommended Approaches
+
+### 4.1 For @deessejs/server - URL Query Parameters
+
+Based on research, the following approaches are recommended in order of preference:
+
+#### Option A: Hono RPC Pattern (Recommended)
+
+```typescript
+// Server-side coercion via z.coerce
+const listUsers = t.query({
+  args: z.object({
+    limit: z.coerce.number().min(1).max(100).default(20),
+    offset: z.coerce.number().default(0),
+  }),
+  handler: async (ctx, args) => {
+    // args.limit is already a number
+  }
+})
+```
+
+**Pros:**
+- Standard Zod pattern
+- Clear intention in schema
+- Works with existing Zod validation
+- Recommended by Hono RPC
+
+**Cons:**
+- Requires user to know about `z.coerce.*`
+- Schema modification required
+
+#### Option B: zodix Helper Schemas
+
+```typescript
+// Create server-side helpers
+const QueryNum = z.preprocess(
+  (arg) => (typeof arg === 'string' ? parseInt(arg) : arg),
+  z.number()
+)
+const QueryBool = z.preprocess(
+  (arg) => {
+    if (typeof arg === 'string') {
+      if (arg === 'true' || arg === '1') return true
+      if (arg === 'false' || arg === '0') return false
+    }
+    return arg
+  },
+  z.boolean()
+)
+
+// Usage
+const listUsers = t.query({
+  args: z.object({
+    limit: QueryNum.default(20),
+    offset: QueryNum.default(0),
+    active: QueryBool,
+  }),
+  handler: async (ctx, args) => { }
+})
+```
+
+**Pros:**
+- Explicit, readable
+- Type-safe conversion
+- Reusable helpers
+
+**Cons:**
+- More verbose than naive coercion
+- Custom helper definitions
+
+#### Option C: Server-Side Naive Coercion (Current Plan)
+
+```typescript
+// In createHonoHandler.ts
+function coerceQueryParams(query: Record<string, string[]>): Record<string, unknown> {
+  const coerced: Record<string, unknown> = {}
+  for (const [key, values] of Object.entries(query)) {
+    const value = values[0]
+    if (value === 'true' || value === '1') coerced[key] = true
+    else if (value === 'false' || value === '0') coerced[key] = false
+    else if (!isNaN(Number(value)) && value !== '') coerced[key] = Number(value)
+    else coerced[key] = value
+  }
+  return coerced
+}
+```
+
+**Pros:**
+- No schema changes required
+- Works universally
+- Backward compatible
+
+**Cons:**
+- Edge cases: `""` → `0`, `"00123"` → `123`
+- Less explicit
+- Schema-aware validation unavailable
+
+---
+
+### 4.2 For @deessejs/server - Array Serialization
+
+**Reference:** Hono RPC `buildSearchParams` config
+
+```typescript
+// Client transport enhancement
+const client = hc<AppType>('http://localhost', {
+  buildSearchParams: (query) => {
+    const searchParams = new URLSearchParams()
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined) continue
+      if (Array.isArray(v)) {
+        v.forEach((item) => searchParams.append(`${k}[]`, String(item)))
+      } else {
+        searchParams.set(k, String(v))
+      }
+    }
+    return searchParams
+  },
+})
+```
+
+**For @deessejs/server transport.ts:**
+
+```typescript
+private buildUrl(path: string, args: unknown, method: string): string {
+  if (method === 'GET' && args && typeof args === 'object') {
+    const searchParams = new URLSearchParams()
+    for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+      if (Array.isArray(value)) {
+        // Repeat param syntax: ?ids=1&ids=2&ids=3
+        for (const item of value) {
+          searchParams.append(key, String(item))
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        console.warn(`Nested object "${key}" skipped in GET request.`)
+        continue
+      } else {
+        searchParams.append(key, String(value))
+      }
+    }
+    return `${base}/${path}?${searchParams}`
+  }
+  return `${base}/${path}`
+}
+```
+
+---
+
+### 4.3 For @deessejs/server - Future Enhancements
+
+| Enhancement | Reference | Priority | Complexity |
+|-------------|-----------|----------|------------|
+| `$url()` / `$path()` helpers | Hono RPC | Medium | Low |
+| `buildSearchParams` config | Hono RPC | Medium | Low |
+| OpenAPI generation | oRPC | Low | High |
+| Helper schemas (NumAsString) | zodix | Medium | Low |
+| Error type narrowing | ElysiaJS Eden | Low | Medium |
+
+---
+
+## 5. Conclusion
+
+### Summary of Findings
+
+1. **Hono RPC** provides the most relevant patterns for @deessejs/server since it already uses Hono
+2. **zodix helper schemas** offer an elegant solution for type-safe URL param parsing
+3. **Naive coercion** (current plan) is acceptable for MVP but has edge cases
+4. **Schema-aware coercion** via `z.coerce.*` is the standard recommended by Hono
+
+### Recommended Next Steps
+
+1. **Implement naive coercion** (current plan) for immediate fix
+2. **Add helper schemas** for better type safety in examples
+3. **Document `z.coerce.*` requirement** for URL query parameters
+4. **Consider `$url()` / `$path()` helpers** for URL building
+
+### Out of Scope
+
+The following are not recommended for current URL params plan but could be future enhancements:
+- OpenAPI generation (complex, different feature)
+- Multi-runtime support (Hono only for now)
+- OpenTelemetry (not in current requirements)
+
+---
+
+## References
+
+### Primary Sources
+
+- [oRPC](https://orpc.io/) - Typesafe APIs Made Simple
+- [Hono RPC Guide](https://hono.dev/docs/guides/rpc) - Type-Safe Fullstack Development
+- [ElysiaJS Eden](https://elysiajs.com/eden/overview) - End-to-End Type Safety
+- [zodix](https://github.com/coji/zodix) - Zod utilities for React Router
+- [FalkZ/zod-search-params](https://github.com/FalkZ/zod-search-params) - Type-safe URL search params
+
+### Secondary Sources
+
+- [APIScout - REST vs tRPC vs GraphQL vs gRPC](https://apiscout.dev/blog/death-of-rest-type-safe-api-patterns-2026) - API Patterns 2026
+- [LogRocket - tRPC vs oRPC](https://blog.logrocket.com/trpc-vs-orpc-type-safe-rpc/) - Comparison Article
+- [tRPC OpenAPI Issue #44](https://github.com/trpc/trpc-openapi/issues/44) - RFC: Support number, boolean, Date in query params
+
+---
+
+## Appendix A: Edge Cases
+
+| Input | Naive Coercion Output | Expected Output |
+|-------|----------------------|-----------------|
+| `""` (empty) | `0` (number) | `""` (string) |
+| `"00123"` | `123` (number) | `123` (number) or `"00123"` (string) |
+| `"123abc"` | `"123abc"` (string) | `"123abc"` (string) |
+| `?ids=1&ids=2` | `{ ids: ['1', '2'] }` (strings) | `{ ids: [1, 2] }` (numbers) |
+| `"true"`/`"1"` | `true` | `true` |
+| `"false"`/`"0"` | `false` | `false` |
+
+## Appendix B: Zod Coercion vs Naive Coercion
+
+| Approach | Code | Pros | Cons |
+|----------|------|------|------|
+| `z.coerce.number()` | Schema-level | Standard, well-supported | Schema modification |
+| `z.preprocess()` | Schema-level | Customizable | Verbose |
+| Naive coercion | Handler-level | Universal, no schema changes | Edge cases, less explicit |
+
+---
+
+*Report generated: 2026-04-27*

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -42,24 +42,18 @@ export class FetchTransport implements Transport {
     if (method === 'GET' && args && typeof args === 'object' && Object.keys(args).length > 0) {
       const searchParams = new URLSearchParams();
 
-      for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+      Object.entries(args).forEach(([key, value]) => {
         if (Array.isArray(value)) {
-          // Arrays: use repeat param syntax ?ids=1&ids=2&ids=3
-          for (const item of value) {
-            searchParams.append(key, String(item));
-          }
+          value.forEach(item => searchParams.append(key, String(item)));
         } else if (typeof value === 'object' && value !== null) {
-          // Nested objects cannot be serialized to URL
-          // Log warning to help users debug issues
           console.warn(
             `[deesse] Nested object "${key}" skipped in GET request. ` +
             `Use POST body for complex queries with nested objects.`
           );
-          continue;
-        } else {
+        } else if (value !== undefined) {
           searchParams.append(key, String(value));
         }
-      }
+      });
 
       return `${base}/${normalizedPath}?${searchParams}`;
     }

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -1,6 +1,13 @@
 import type { Transport, RequestOptions } from './types';
 
 /**
+ * Type guard to check if value is a plain object (not null, not array).
+ * Note: typeof null === 'object' in JavaScript, hence the null check.
+ */
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
  * Fetch-based transport implementation for making HTTP requests.
  * Uses POST by default with JSON body, and GET with query params.
  */
@@ -39,13 +46,13 @@ export class FetchTransport implements Transport {
       base = base.endsWith('/') ? base.slice(0, -1) : base;
     }
 
-    if (method === 'GET' && args && typeof args === 'object' && Object.keys(args).length > 0) {
+    if (method === 'GET' && args && isPlainObject(args) && Object.keys(args).length > 0) {
       const searchParams = new URLSearchParams();
 
       Object.entries(args).forEach(([key, value]) => {
         if (Array.isArray(value)) {
           value.forEach(item => searchParams.append(key, String(item)));
-        } else if (typeof value === 'object' && value !== null) {
+        } else if (isPlainObject(value)) {
           console.warn(
             `[deesse] Nested object "${key}" skipped in GET request. ` +
             `Use POST body for complex queries with nested objects.`

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -40,9 +40,27 @@ export class FetchTransport implements Transport {
     }
 
     if (method === 'GET' && args && typeof args === 'object' && Object.keys(args).length > 0) {
-      const searchParams = new URLSearchParams(
-        args as Record<string, string>
-      );
+      const searchParams = new URLSearchParams();
+
+      for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+        if (Array.isArray(value)) {
+          // Arrays: use repeat param syntax ?ids=1&ids=2&ids=3
+          for (const item of value) {
+            searchParams.append(key, String(item));
+          }
+        } else if (typeof value === 'object' && value !== null) {
+          // Nested objects cannot be serialized to URL
+          // Log warning to help users debug issues
+          console.warn(
+            `[deesse] Nested object "${key}" skipped in GET request. ` +
+            `Use POST body for complex queries with nested objects.`
+          );
+          continue;
+        } else {
+          searchParams.append(key, String(value));
+        }
+      }
+
       return `${base}/${normalizedPath}?${searchParams}`;
     }
 

--- a/packages/server-hono/src/createHonoHandler.ts
+++ b/packages/server-hono/src/createHonoHandler.ts
@@ -33,23 +33,16 @@ function isMutationMethod(method: string): boolean {
  * - Empty strings remain empty strings (not coerced to 0)
  * - Everything else → string
  */
-function coerceQueryParams(query: Record<string, string[]>): Record<string, unknown> {
-  const coerced: Record<string, unknown> = {};
-  for (const [key, values] of Object.entries(query)) {
-    const value = values[0]; // Take first value from array (Hono returns string[])
-    if (value === 'true' || value === '1') {
-      coerced[key] = true;
-    } else if (value === 'false' || value === '0') {
-      coerced[key] = false;
-    } else if (value !== '' && !isNaN(Number(value))) {
-      // Guard against empty string to prevent "" → 0 coercion bug
-      coerced[key] = Number(value);
-    } else {
-      coerced[key] = value;
-    }
-  }
-  return coerced;
-}
+const coerceQueryParams = (query: Record<string, string[]>): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(query).map(([key, values]) => {
+      const value = values[0];
+      if (value === 'true' || value === '1') return [key, true];
+      if (value === 'false' || value === '0') return [key, false];
+      if (value !== '' && !isNaN(Number(value))) return [key, Number(value)];
+      return [key, value];
+    })
+  );
 
 /**
  * Gets a procedure function from the client proxy using a dot-separated path

--- a/packages/server-hono/src/createHonoHandler.ts
+++ b/packages/server-hono/src/createHonoHandler.ts
@@ -25,6 +25,33 @@ function isMutationMethod(method: string): boolean {
 }
 
 /**
+ * Coerces URL query string values to primitive types.
+ * Mirrors tRPC OpenAPI behavior:
+ * - "true"/"1" → true (boolean)
+ * - "false"/"0" → false (boolean)
+ * - Numeric strings → number
+ * - Empty strings remain empty strings (not coerced to 0)
+ * - Everything else → string
+ */
+function coerceQueryParams(query: Record<string, string[]>): Record<string, unknown> {
+  const coerced: Record<string, unknown> = {};
+  for (const [key, values] of Object.entries(query)) {
+    const value = values[0]; // Take first value from array (Hono returns string[])
+    if (value === 'true' || value === '1') {
+      coerced[key] = true;
+    } else if (value === 'false' || value === '0') {
+      coerced[key] = false;
+    } else if (value !== '' && !isNaN(Number(value))) {
+      // Guard against empty string to prevent "" → 0 coercion bug
+      coerced[key] = Number(value);
+    } else {
+      coerced[key] = value;
+    }
+  }
+  return coerced;
+}
+
+/**
  * Gets a procedure function from the client proxy using a dot-separated path
  */
 function getProcedure(client: unknown, pathParts: string[]): ((args: unknown) => Promise<Result<unknown>>) | undefined {
@@ -68,9 +95,9 @@ export function createHonoHandler(client: HTTPClient): Hono {
         args = {};
       }
     } else {
-      // For queries, parse search params
+      // For queries, parse search params with type coercion
       const queryParams = c.req.queries();
-      args = queryParams as Record<string, unknown>;
+      args = coerceQueryParams(queryParams);
     }
 
     // Get the procedure function using the proxy-based access

--- a/packages/server-hono/tests/createHonoHandler.test.ts
+++ b/packages/server-hono/tests/createHonoHandler.test.ts
@@ -65,3 +65,167 @@ describe("createHonoHandler", () => {
     expect(app).toBeDefined();
   });
 });
+
+describe("coerceQueryParams", () => {
+  // We need to access the internal function for testing
+  // For now, we test via the public API behavior
+
+  it("should coerce numeric strings to numbers in GET requests", async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({ limit: z.number() }),
+      handler: async () => {
+        return ok({ count: 0 });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with ?limit=20 (string from URL)
+    const request = new Request("http://localhost/api/users.list?limit=20");
+    const response = await app.fetch(request);
+    const body = await response.json();
+
+    // If coercion works, validation passes and returns ok: true
+    // If no coercion, limit would be "20" (string) and z.number() validation would fail
+    expect(body.ok).toBe(true);
+  });
+
+  it("should coerce boolean strings to booleans in GET requests", async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({ active: z.boolean() }),
+      handler: async () => {
+        return ok({ count: 0 });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with ?active=true (string from URL)
+    const request = new Request("http://localhost/api/users.list?active=true");
+    const response = await app.fetch(request);
+    const body = await response.json();
+
+    expect(body.ok).toBe(true);
+  });
+
+  it("should coerce '1' to boolean true", async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({ active: z.boolean() }),
+      handler: async () => {
+        return ok({ count: 0 });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with ?active=1 (string from URL)
+    const request = new Request("http://localhost/api/users.list?active=1");
+    const response = await app.fetch(request);
+    const body = await response.json();
+
+    expect(body.ok).toBe(true);
+  });
+
+  it("should coerce '0' to boolean false", async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({ active: z.boolean() }),
+      handler: async () => {
+        return ok({ count: 0 });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with ?active=0 (string from URL)
+    const request = new Request("http://localhost/api/users.list?active=0");
+    const response = await app.fetch(request);
+    const body = await response.json();
+
+    expect(body.ok).toBe(true);
+  });
+
+  it("should preserve empty strings as empty strings", async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({ name: z.string() }),
+      handler: async () => {
+        return ok({ count: 0 });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with ?name= (empty string)
+    const request = new Request("http://localhost/api/users.list?name=");
+    const response = await app.fetch(request);
+    const body = await response.json();
+
+    // Empty string should NOT be coerced to 0
+    expect(body.ok).toBe(true);
+  });
+
+  it("should handle mixed types in query", async () => {
+    const { t, createAPI } = defineContext({ context: {} });
+
+    const listUsers = t.query({
+      args: z.object({
+        limit: z.number(),
+        active: z.boolean(),
+        name: z.string(),
+      }),
+      handler: async () => {
+        return ok({ count: 0 });
+      },
+    });
+
+    const api = createAPI({
+      router: t.router({ users: { list: listUsers } }),
+    });
+
+    const client = createPublicAPI(api);
+    const app = createHonoHandler(client);
+
+    // Simulate GET request with mixed types
+    const request = new Request(
+      "http://localhost/api/users.list?limit=10&active=true&name=john"
+    );
+    const response = await app.fetch(request);
+    const body = await response.json();
+
+    expect(body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
- Add coerceQueryParams() function for automatic type coercion
- Coerces "true"/"1" → true, "false"/"0" → false
- Numeric strings → numbers, preserving empty strings
- Add 6 tests for coerceQueryParams() via public API
- Add implementation plan and research report